### PR TITLE
Temporarily disable CI runs against nightly Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
           - minimal
           - stable
           - beta
-          - nightly
+          # TODO: Re-enable nightly tests once fix for
+          # <https://github.com/zowens/crc32c/issues/51> is released
+          #- nightly
         include:
           - os: macos-latest
             toolchain: stable


### PR DESCRIPTION
Nightly Rust builds are currently broken by <https://github.com/zowens/crc32c/issues/51>, which is taking too long to get a fix released.