### PR TITLE
Improve logging configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-stream",
+ "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-runtime-api",
@@ -840,17 +841,20 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "reqwest",
+ "reqwest-middleware",
  "rstest",
  "serde",
  "serde_json",
  "serde_yaml",
  "smartstring",
+ "task-local-extensions",
  "tera",
  "thiserror",
  "time",
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
  "url",
  "xml-rs",
@@ -1494,6 +1498,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1904,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1909,6 +1924,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 0.2.11",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
 ]
 
 [[package]]
@@ -2372,6 +2402,15 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.79"
 async-stream = "0.3.5"
+async-trait = "0.1.77"
 aws-config = { version = "1.1.4", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.14.0"
 aws-smithy-runtime-api = "1.1.4"
@@ -32,16 +33,19 @@ itertools = "0.12.1"
 moka = { version = "0.12.5", features = ["future"] }
 percent-encoding = "2.3.1"
 reqwest = { version = "0.11.24", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+reqwest-middleware = "0.2.4"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0.113", features = ["preserve_order"] }
 serde_yaml = "0.9.31"
 smartstring = "1.0.1"
+task-local-extensions = "0.1.4"
 tera = { version = "1.19.1", default-features = false }
 thiserror = "1.0.56"
 time = { version = "0.3.34", features = ["formatting", "macros", "parsing", "serde"] }
 tokio = { version = "1.36.0", features = ["macros", "net", "rt-multi-thread"] }
 tower = "0.4.13"
 tower-http = { version = "0.5.1", features = ["set-header", "trace"] }
+tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = { version = "2.5.0", features = ["serde"] }
 xml-rs = "0.8.19"

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
         .with(
             Targets::new()
                 .with_target(env!("CARGO_CRATE_NAME"), Level::TRACE)
+                .with_target("aws_config", Level::DEBUG)
                 .with_target("reqwest", Level::TRACE)
                 .with_target("tower_http", Level::TRACE)
                 .with_default(Level::INFO),

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,13 @@ use axum::{
     Router,
 };
 use clap::Parser;
+use std::io::{stderr, IsTerminal};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tower::service_fn;
 use tower_http::{set_header::response::SetResponseHeaderLayer, trace::TraceLayer};
-use tracing_subscriber::filter::LevelFilter;
+use tracing::Level;
+use tracing_subscriber::{filter::Targets, prelude::*};
 
 static STYLESHEET: &str = include_str!("dav/static/styles.css");
 
@@ -57,8 +59,19 @@ struct Arguments {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Arguments::parse();
-    tracing_subscriber::fmt()
-        .with_max_level(LevelFilter::TRACE)
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(stderr().is_terminal())
+                .with_writer(stderr),
+        )
+        .with(
+            Targets::new()
+                .with_target(env!("CARGO_CRATE_NAME"), Level::TRACE)
+                .with_target("reqwest", Level::TRACE)
+                .with_target("tower_http", Level::TRACE)
+                .with_default(Level::INFO),
+        )
         .init();
     let dandi = DandiClient::new(args.api_url)?;
     let zarrman = ZarrManClient::new()?;


### PR DESCRIPTION
Part of #5.

This PR does the following:

- Emits a log event before & after each HTTP request made to the Dandi Archive and datasets.datalad.org (and also to S3 when determining a bucket's region)
- Configures logging to be emitted on stderr instead of stdout
- Configures logging to not use ANSI colors when stderr is redirected
- Configures logging to show all events from `dandidav` and certain select "important" libraries, along with all INFO & above events from all other libraries