### PR TITLE
Add breadcrumbs to web view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ In Development
     - Disable log coloration when stderr is not a terminal
     - Suppress noisy & irrelevant log messages from various dependencies
     - Log errors that cause 404 and 500 responses
+- Added breadcrumbs to HTML views of collections
 
 v0.2.0 (2024-02-07)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ In Development
     - Suppress noisy & irrelevant log messages from various dependencies
     - Log errors that cause 404 and 500 responses
 - Added breadcrumbs to HTML views of collections
+- `FAST_NOT_EXIST` components are now checked for case-insensitively
 
 v0.2.0 (2024-02-07)
 -------------------

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -39,7 +39,8 @@ pub(crate) static HTML_TIMESTAMP_FORMAT: &[FormatItem<'_>] = format_description!
 );
 
 /// If a client makes a request for a resource with one of these names as a
-/// component, assume it doesn't exist without checking the Archive.
+/// component (case insensitive), assume it doesn't exist without bothering to
+/// check the backend.
 ///
 /// This list must be kept in sorted order; this is enforced by a test below.
 pub(crate) static FAST_NOT_EXIST: &[&str] = &[".bzr", ".git", ".nols", ".svn"];
@@ -51,7 +52,7 @@ mod tests {
     #[test]
     fn test_fast_not_exist_is_sorted() {
         assert!(FAST_NOT_EXIST.windows(2).all(|ab| {
-            assert!(ab.len() >= 2);
+            assert!(ab.len() == 2);
             ab[0] < ab[1]
         }));
     }

--- a/src/dav/path.rs
+++ b/src/dav/path.rs
@@ -163,211 +163,289 @@ fn join_parts<I: Iterator<Item = Component>>(iter: I) -> Option<Option<PurePath>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_matches::assert_matches;
-    use rstest::rstest;
 
-    #[rstest]
-    #[case("/foo")]
-    #[case("/dandisets/123")]
-    #[case("/dandisets/draft")]
-    #[case("/dandisets/000123/0.201234.1")]
-    #[case("/dandisets/000123/releases/draft")]
-    #[case("/dandisets/000123/draft/.git/index")]
-    #[case("/dandisets/000123/draft/foo/.svn")]
-    #[case("/dandisets/000123/draft/foo/%2esvn")]
-    #[case("/dandisets/000123/draft/foo%2f.svn")]
-    #[case("/dandisets/000123/draft/foo/.nols/bar")]
-    #[case("/dandisets/000123/draft/.bzr")]
-    fn test_bad_uri_paths(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_eq!(DavPath::from_components(parts), None);
+    mod split_components {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            let s = "";
+            let mut parts = SplitComponents::new(s);
+            assert!(parts.next().is_none());
+        }
+
+        #[test]
+        fn slash() {
+            let s = "/";
+            let mut parts = SplitComponents::new(s);
+            assert!(parts.next().is_none());
+        }
+
+        #[test]
+        fn double_slash() {
+            let s = "//";
+            let mut parts = SplitComponents::new(s);
+            assert!(parts.next().is_none());
+        }
+
+        #[test]
+        fn foo() {
+            let s = "/foo";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo"]);
+        }
+
+        #[test]
+        fn foo_slash() {
+            let s = "/foo/";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo"]);
+        }
+
+        #[test]
+        fn no_slash_foo() {
+            let s = "foo";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo"]);
+        }
+
+        #[test]
+        fn foo_bar() {
+            let s = "/foo/bar";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo", "bar"]);
+        }
+
+        #[test]
+        fn foo_bar_slash() {
+            let s = "/foo/bar/";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo", "bar"]);
+        }
+
+        #[test]
+        fn foo_bar_all_double_slash() {
+            let s = "//foo//bar//";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo", "bar"]);
+        }
+
+        #[test]
+        fn foo_double_slash_bar() {
+            let s = "/foo//bar";
+            let parts = SplitComponents::new(s).collect::<Vec<_>>();
+            assert_eq!(parts, ["foo", "bar"]);
+        }
     }
 
-    #[rstest]
-    #[case("")]
-    #[case("/")]
-    #[case("//")]
-    fn test_root(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_eq!(DavPath::from_components(parts), Some(DavPath::Root));
-    }
+    mod dav_path_from_components {
+        use super::*;
+        use assert_matches::assert_matches;
+        use rstest::rstest;
 
-    #[rstest]
-    #[case("/dandisets")]
-    #[case("/dandisets/")]
-    #[case("/dandisets//")]
-    #[case("//dandisets/")]
-    #[case("/Dandisets")]
-    #[case("/DandiSets")]
-    fn test_dandiset_index(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_eq!(
-            DavPath::from_components(parts),
-            Some(DavPath::DandisetIndex)
-        );
-    }
+        #[rstest]
+        #[case("/foo")]
+        #[case("/dandisets/123")]
+        #[case("/dandisets/draft")]
+        #[case("/dandisets/000123/0.201234.1")]
+        #[case("/dandisets/000123/releases/draft")]
+        #[case("/dandisets/000123/draft/.git/index")]
+        #[case("/dandisets/000123/draft/foo/.svn")]
+        #[case("/dandisets/000123/draft/foo/%2esvn")]
+        #[case("/dandisets/000123/draft/foo%2f.svn")]
+        #[case("/dandisets/000123/draft/foo/.nols/bar")]
+        #[case("/dandisets/000123/draft/.bzr")]
+        fn test_bad_uri_paths(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_eq!(DavPath::from_components(parts), None);
+        }
 
-    #[rstest]
-    #[case("/dandisets/000123")]
-    #[case("/dandisets/000123/")]
-    #[case("/dandisets//000123")]
-    #[case("/Dandisets/000123")]
-    #[case("/DandiSets/000123")]
-    fn test_dandiset(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::Dandiset {dandiset_id}) => {
-            assert_eq!(dandiset_id, "000123");
-        });
-    }
+        #[rstest]
+        #[case("")]
+        #[case("/")]
+        #[case("//")]
+        fn test_root(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_eq!(DavPath::from_components(parts), Some(DavPath::Root));
+        }
 
-    #[rstest]
-    #[case("/dandisets/000123/releases")]
-    #[case("/dandisets/000123/releases/")]
-    #[case("/Dandisets/000123/Releases")]
-    #[case("/DandiSets/000123/ReLeAsEs/")]
-    fn test_dandiset_releases(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::DandisetReleases {dandiset_id}) => {
-            assert_eq!(dandiset_id, "000123");
-        });
-    }
+        #[rstest]
+        #[case("/dandisets")]
+        #[case("/dandisets/")]
+        #[case("/dandisets//")]
+        #[case("//dandisets/")]
+        #[case("/Dandisets")]
+        #[case("/DandiSets")]
+        fn test_dandiset_index(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_eq!(
+                DavPath::from_components(parts),
+                Some(DavPath::DandisetIndex)
+            );
+        }
 
-    #[rstest]
-    #[case("/dandisets/000123/draft")]
-    #[case("/dandisets/000123/draft/")]
-    #[case("/Dandisets/000123/Draft")]
-    #[case("/DandiSets/000123/dRaFt/")]
-    fn test_dandiset_draft(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_eq!(version, VersionSpec::Draft);
-        });
-    }
-
-    #[rstest]
-    #[case("/dandisets/000123/latest")]
-    #[case("/dandisets/000123/latest/")]
-    #[case("/Dandisets/000123/Latest")]
-    #[case("/DandiSets/000123/LaTeST/")]
-    fn test_dandiset_latest(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_eq!(version, VersionSpec::Latest);
-        });
-    }
-
-    #[rstest]
-    #[case("/dandisets/000123/releases/0.240123.42")]
-    #[case("/dandisets/000123/releases/0.240123.42/")]
-    #[case("/Dandisets/000123/Releases//0.240123.42")]
-    #[case("/DandiSets/000123/ReLeAsEs/0.240123.42//")]
-    fn test_dandiset_published_version(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_matches!(version, VersionSpec::Published(v) => {
-                assert_eq!(v, "0.240123.42");
+        #[rstest]
+        #[case("/dandisets/000123")]
+        #[case("/dandisets/000123/")]
+        #[case("/dandisets//000123")]
+        #[case("/Dandisets/000123")]
+        #[case("/DandiSets/000123")]
+        fn test_dandiset(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::Dandiset {dandiset_id}) => {
+                assert_eq!(dandiset_id, "000123");
             });
-        });
-    }
+        }
 
-    #[rstest]
-    #[case("/dandisets/000123/draft/dandiset.yaml")]
-    #[case("/dandisets/000123/draft/dandiset.yaml/")]
-    #[case("/Dandisets/000123/Draft/dandiset.yaml")]
-    #[case("/DandiSets/000123/dRaFt/dandiset.yaml")]
-    fn test_dandiset_draft_dandiset_yaml(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::DandisetYaml {dandiset_id, version}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_eq!(version, VersionSpec::Draft);
-        });
-    }
-
-    #[rstest]
-    #[case("/dandisets/000123/draft/Dandiset.yaml", "Dandiset.yaml")]
-    #[case("/dandisets/000123/draft/dandiset.yml", "dandiset.yml")]
-    #[case("/dandisets/000123/draft/foo", "foo")]
-    #[case("/dandisets/000123/draft/foo/bar", "foo/bar")]
-    #[case("/dandisets/000123/draft/foo%2fbar", "foo/bar")]
-    #[case("/dandisets/000123/draft/foo%20bar", "foo bar")]
-    #[case("/dandisets/000123/draft/foo/./bar", "foo/bar")]
-    #[case("/dandisets/000123/draft//foo//bar/", "foo/bar")]
-    #[case("/dandisets/000123/draft/foo/../bar", "bar")]
-    #[case("/dandisets/000123/draft/foo/%2e%2e/bar", "bar")]
-    fn test_dandiset_draft_resource(#[case] s: &str, #[case] respath: &str) {
-        let parts = split_uri_path(s).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_eq!(version, VersionSpec::Draft);
-            assert_eq!(path, respath);
-        });
-    }
-
-    #[rstest]
-    #[case("/dandisets/000123/latest/Dandiset.yaml", "Dandiset.yaml")]
-    #[case("/dandisets/000123/latest/dandiset.yml", "dandiset.yml")]
-    #[case("/dandisets/000123/latest/foo", "foo")]
-    #[case("/dandisets/000123/latest/foo/bar", "foo/bar")]
-    #[case("/dandisets/000123/latest/foo%2fbar", "foo/bar")]
-    #[case("/dandisets/000123/latest/foo%20bar", "foo bar")]
-    #[case("/dandisets/000123/latest/foo/./bar", "foo/bar")]
-    #[case("/dandisets/000123/latest//foo//bar/", "foo/bar")]
-    fn test_dandiset_latest_resource(#[case] s: &str, #[case] respath: &str) {
-        let parts = split_uri_path(s).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_eq!(version, VersionSpec::Latest);
-            assert_eq!(path, respath);
-        });
-    }
-
-    #[rstest]
-    #[case(
-        "/dandisets/000123/releases/0.240123.42/Dandiset.yaml",
-        "Dandiset.yaml"
-    )]
-    #[case("/dandisets/000123/releases/0.240123.42/dandiset.yml", "dandiset.yml")]
-    #[case("/dandisets/000123/releases/0.240123.42/foo", "foo")]
-    #[case("/dandisets/000123/Releases/0.240123.42/foo/bar", "foo/bar")]
-    #[case("/dandisets/000123/rElEaSeS/0.240123.42/foo%2fbar", "foo/bar")]
-    #[case("/dandisets/000123/ReLeAsEs/0.240123.42/foo%20bar", "foo bar")]
-    #[case("/dandisets/000123/RELEASES/0.240123.42/foo/./bar", "foo/bar")]
-    #[case("/dandisets/000123/releases/0.240123.42//foo//bar/", "foo/bar")]
-    fn test_dandiset_publish_version_resource(#[case] s: &str, #[case] respath: &str) {
-        let parts = split_uri_path(s).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
-            assert_eq!(dandiset_id, "000123");
-            assert_matches!(version, VersionSpec::Published(v) => {
-                assert_eq!(v, "0.240123.42");
+        #[rstest]
+        #[case("/dandisets/000123/releases")]
+        #[case("/dandisets/000123/releases/")]
+        #[case("/Dandisets/000123/Releases")]
+        #[case("/DandiSets/000123/ReLeAsEs/")]
+        fn test_dandiset_releases(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::DandisetReleases {dandiset_id}) => {
+                assert_eq!(dandiset_id, "000123");
             });
-            assert_eq!(path, respath);
-        });
-    }
+        }
 
-    #[rstest]
-    #[case("/zarrs")]
-    #[case("/zarrs/")]
-    #[case("/zarrs//")]
-    #[case("//zarrs/")]
-    #[case("/Zarrs")]
-    #[case("/ZARRS")]
-    fn test_zarr_index(#[case] path: &str) {
-        let parts = split_uri_path(path).unwrap();
-        assert_eq!(DavPath::from_components(parts), Some(DavPath::ZarrIndex));
-    }
+        #[rstest]
+        #[case("/dandisets/000123/draft")]
+        #[case("/dandisets/000123/draft/")]
+        #[case("/Dandisets/000123/Draft")]
+        #[case("/DandiSets/000123/dRaFt/")]
+        fn test_dandiset_draft(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_eq!(version, VersionSpec::Draft);
+            });
+        }
 
-    #[rstest]
-    #[case("/zarrs/123", "123")]
-    #[case("/zarrs/123/", "123")]
-    #[case("/zarrs/123/abc", "123/abc")]
-    #[case("/ZARRS/123/ABC", "123/ABC")]
-    fn test_zarr_path(#[case] s: &str, #[case] respath: &str) {
-        let parts = split_uri_path(s).unwrap();
-        assert_matches!(DavPath::from_components(parts), Some(DavPath::ZarrPath {path}) => {
-            assert_eq!(path, respath);
-        });
+        #[rstest]
+        #[case("/dandisets/000123/latest")]
+        #[case("/dandisets/000123/latest/")]
+        #[case("/Dandisets/000123/Latest")]
+        #[case("/DandiSets/000123/LaTeST/")]
+        fn test_dandiset_latest(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_eq!(version, VersionSpec::Latest);
+            });
+        }
+
+        #[rstest]
+        #[case("/dandisets/000123/releases/0.240123.42")]
+        #[case("/dandisets/000123/releases/0.240123.42/")]
+        #[case("/Dandisets/000123/Releases//0.240123.42")]
+        #[case("/DandiSets/000123/ReLeAsEs/0.240123.42//")]
+        fn test_dandiset_published_version(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::Version {dandiset_id, version}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_matches!(version, VersionSpec::Published(v) => {
+                    assert_eq!(v, "0.240123.42");
+                });
+            });
+        }
+
+        #[rstest]
+        #[case("/dandisets/000123/draft/dandiset.yaml")]
+        #[case("/dandisets/000123/draft/dandiset.yaml/")]
+        #[case("/Dandisets/000123/Draft/dandiset.yaml")]
+        #[case("/DandiSets/000123/dRaFt/dandiset.yaml")]
+        fn test_dandiset_draft_dandiset_yaml(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::DandisetYaml {dandiset_id, version}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_eq!(version, VersionSpec::Draft);
+            });
+        }
+
+        #[rstest]
+        #[case("/dandisets/000123/draft/Dandiset.yaml", "Dandiset.yaml")]
+        #[case("/dandisets/000123/draft/dandiset.yml", "dandiset.yml")]
+        #[case("/dandisets/000123/draft/foo", "foo")]
+        #[case("/dandisets/000123/draft/foo/bar", "foo/bar")]
+        #[case("/dandisets/000123/draft/foo%2fbar", "foo/bar")]
+        #[case("/dandisets/000123/draft/foo%20bar", "foo bar")]
+        #[case("/dandisets/000123/draft/foo/./bar", "foo/bar")]
+        #[case("/dandisets/000123/draft//foo//bar/", "foo/bar")]
+        #[case("/dandisets/000123/draft/foo/../bar", "bar")]
+        #[case("/dandisets/000123/draft/foo/%2e%2e/bar", "bar")]
+        fn test_dandiset_draft_resource(#[case] s: &str, #[case] respath: &str) {
+            let parts = split_uri_path(s).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_eq!(version, VersionSpec::Draft);
+                assert_eq!(path, respath);
+            });
+        }
+
+        #[rstest]
+        #[case("/dandisets/000123/latest/Dandiset.yaml", "Dandiset.yaml")]
+        #[case("/dandisets/000123/latest/dandiset.yml", "dandiset.yml")]
+        #[case("/dandisets/000123/latest/foo", "foo")]
+        #[case("/dandisets/000123/latest/foo/bar", "foo/bar")]
+        #[case("/dandisets/000123/latest/foo%2fbar", "foo/bar")]
+        #[case("/dandisets/000123/latest/foo%20bar", "foo bar")]
+        #[case("/dandisets/000123/latest/foo/./bar", "foo/bar")]
+        #[case("/dandisets/000123/latest//foo//bar/", "foo/bar")]
+        fn test_dandiset_latest_resource(#[case] s: &str, #[case] respath: &str) {
+            let parts = split_uri_path(s).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_eq!(version, VersionSpec::Latest);
+                assert_eq!(path, respath);
+            });
+        }
+
+        #[rstest]
+        #[case(
+            "/dandisets/000123/releases/0.240123.42/Dandiset.yaml",
+            "Dandiset.yaml"
+        )]
+        #[case("/dandisets/000123/releases/0.240123.42/dandiset.yml", "dandiset.yml")]
+        #[case("/dandisets/000123/releases/0.240123.42/foo", "foo")]
+        #[case("/dandisets/000123/Releases/0.240123.42/foo/bar", "foo/bar")]
+        #[case("/dandisets/000123/rElEaSeS/0.240123.42/foo%2fbar", "foo/bar")]
+        #[case("/dandisets/000123/ReLeAsEs/0.240123.42/foo%20bar", "foo bar")]
+        #[case("/dandisets/000123/RELEASES/0.240123.42/foo/./bar", "foo/bar")]
+        #[case("/dandisets/000123/releases/0.240123.42//foo//bar/", "foo/bar")]
+        fn test_dandiset_publish_version_resource(#[case] s: &str, #[case] respath: &str) {
+            let parts = split_uri_path(s).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::DandiResource {dandiset_id, version, path}) => {
+                assert_eq!(dandiset_id, "000123");
+                assert_matches!(version, VersionSpec::Published(v) => {
+                    assert_eq!(v, "0.240123.42");
+                });
+                assert_eq!(path, respath);
+            });
+        }
+
+        #[rstest]
+        #[case("/zarrs")]
+        #[case("/zarrs/")]
+        #[case("/zarrs//")]
+        #[case("//zarrs/")]
+        #[case("/Zarrs")]
+        #[case("/ZARRS")]
+        fn test_zarr_index(#[case] path: &str) {
+            let parts = split_uri_path(path).unwrap();
+            assert_eq!(DavPath::from_components(parts), Some(DavPath::ZarrIndex));
+        }
+
+        #[rstest]
+        #[case("/zarrs/123", "123")]
+        #[case("/zarrs/123/", "123")]
+        #[case("/zarrs/123/abc", "123/abc")]
+        #[case("/ZARRS/123/ABC", "123/ABC")]
+        fn test_zarr_path(#[case] s: &str, #[case] respath: &str) {
+            let parts = split_uri_path(s).unwrap();
+            assert_matches!(DavPath::from_components(parts), Some(DavPath::ZarrPath {path}) => {
+                assert_eq!(path, respath);
+            });
+        }
     }
 }

--- a/src/dav/static/styles.css
+++ b/src/dav/static/styles.css
@@ -1,3 +1,8 @@
+div.breadcrumbs {
+    margin-bottom: 16px;
+    font: 11px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+}
+
 table {
     border-collapse: collapse;
     border-spacing: 0;

--- a/src/dav/templates/collection.html.tera
+++ b/src/dav/templates/collection.html.tera
@@ -5,6 +5,11 @@
     <link rel="stylesheet" type="text/css" href="/.static/styles.css"/>
 </head>
 <body>
+    <div class="breadcrumbs">
+        {% for bc in breadcrumbs %}
+        <a href="{{bc.href}}">{{bc.name}}</a> {% if not loop.last %} / {% endif %}
+        {% endfor %}
+    </div>
     <table class="collection" border="1">
         <tr>
             <th>Name</th>

--- a/src/paths/component.rs
+++ b/src/paths/component.rs
@@ -12,8 +12,10 @@ fn validate(s: &str) -> Result<(), ParseComponentError> {
         Err(ParseComponentError::Slash)
     } else if s.contains('\0') {
         Err(ParseComponentError::Nul)
-    } else if s == "." || s == ".." {
-        Err(ParseComponentError::SpecialDir)
+    } else if s == "." {
+        Err(ParseComponentError::CurDir)
+    } else if s == ".." {
+        Err(ParseComponentError::ParentDir)
     } else {
         Ok(())
     }
@@ -41,8 +43,10 @@ pub(crate) enum ParseComponentError {
     Slash,
     #[error("path components cannot contain NUL")]
     Nul,
-    #[error(r#"path components cannot equal "." or "..""#)]
-    SpecialDir,
+    #[error(r#"path components cannot equal ".""#)]
+    CurDir,
+    #[error(r#"path components cannot equal "..""#)]
+    ParentDir,
 }
 
 #[cfg(test)]

--- a/src/paths/purepath.rs
+++ b/src/paths/purepath.rs
@@ -83,6 +83,15 @@ impl PurePath {
         self.0.push('/');
         self.0.push_str(c.as_ref());
     }
+
+    pub(crate) fn from_components<I: IntoIterator<Item = Component>>(iter: I) -> Option<PurePath> {
+        let mut iter = iter.into_iter();
+        let mut path = PurePath::from(iter.next()?);
+        for c in iter {
+            path.push(&c);
+        }
+        Some(path)
+    }
 }
 
 impl From<Component> for PurePath {


### PR DESCRIPTION
Closes #14.

Screenshot in Safari:

![breadcrumbs](https://github.com/dandi/dandidav/assets/98207/4be73d75-6e30-4444-a80f-4c3264518460)

Styling of individual breadcrumbs has been deferred to #72.

In addition, while refactoring in order to implement breadcrumbs, the check for ".git" and similar components in request paths (to trigger an early 404) was made case-insensitive.