### PR TITLE
Add `--prefer-s3-redirects` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ In Development
 - Format sizes in the web view in "1.23 MiB" style
 - Zarr entries under `/zarrs/` are now served with ".zarr" extensions
 - Use `<thead>` and `<tbody>` in collection tables in web view
+- Add `--prefer-s3-redirects` option for redirecting requests for blob assets
+  directly to S3 instead of to Archive URLs that redirect to signed S3 URLs
 
 v0.2.0 (2024-02-07)
 -------------------

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Features
 - `GET` requests for non-collection resources are replied to with 307 redirects
   to S3
 
-    - Note that HTML pages for collections link directly to S3 URLs, but this
-      is just to save on a request; if you directly access, say,
+    - Note that HTML pages for collections link blob assets & Zarr entries
+      directly to download URLs rather than to URLs served by `dandidav`, but
+      this is just to save on a request; if you directly access, say,
       <http://localhost:8080/dandisets/000027/draft/sub-RAT123/sub-RAT123.nwb>,
       either by editing the browser address bar or via the command line, you
       will see the redirect.
@@ -39,6 +40,9 @@ Features
       signed S3 URL that specifies the download file name so that downloaded
       asset blobs will be given the file name of their asset instead of the
       blob ID.
+
+        - This can be changed via the `--prefer-s3-redirects` command-line
+          option.
 
 - Hierarchies served:
 
@@ -96,6 +100,13 @@ Options
 
 - `-p <PORT>`, `--port <PORT>` — Specify the port for the server to listen on
   [default: 8080]
+
+- `--prefer-s3-redirects` — Redirect requests for blob assets directly to S3
+  instead of to Archive URLs that redirect to signed S3 URLs.
+
+    Note that this only affects `GET` requests made directly to blob assets.
+    Links to blob assets in the web view will continue to point to Archive
+    URLs.
 
 - `-T <TITLE>`, `--title <TITLE>` — Specify the site name to use in HTML/web
   views of collections (used inside `<title>`'s and as the root breadcrumb

--- a/src/dandi/types.rs
+++ b/src/dandi/types.rs
@@ -178,17 +178,18 @@ impl BlobAsset {
         self.metadata.digest.dandi_etag.as_deref()
     }
 
-    pub(crate) fn download_url(&self) -> Option<&Url> {
-        // Prefer the non-S3 URLs with the expectation that they are Archive
-        // download URLs that redirect to signed S3 URLs that set
-        // `Content-Disposition`, thereby ensuring that the file gets the right
-        // filename when downloaded in a browser.
-        let (s3urls, non_s3urls): (Vec<_>, Vec<_>) = self
-            .metadata
+    pub(crate) fn archive_url(&self) -> Option<&Url> {
+        self.metadata
             .content_url
             .iter()
-            .partition(|url| S3Location::parse_url(url).is_ok());
-        non_s3urls.first().or_else(|| s3urls.first()).copied()
+            .find(|url| S3Location::parse_url(url).is_err())
+    }
+
+    pub(crate) fn s3_url(&self) -> Option<&Url> {
+        self.metadata
+            .content_url
+            .iter()
+            .find(|url| S3Location::parse_url(url).is_ok())
     }
 }
 

--- a/src/dav/html.rs
+++ b/src/dav/html.rs
@@ -242,6 +242,7 @@ fn formatsize(size: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dav::types::Redirect;
     use rstest::rstest;
 
     #[rstest]
@@ -294,11 +295,11 @@ mod tests {
                     size: Some(0),
                     etag: Some(r#""00000000""#.into()),
                     kind: ResourceKind::Blob,
-                    content: DavContent::Redirect(
+                    content: DavContent::Redirect(Redirect::Direct(
                         "https://dandiarchive-test.s3.amazonaws.com/blobs/empty.txt"
                             .parse()
                             .unwrap(),
-                    ),
+                    )),
                     metadata_url: Some(
                         "https://api-test.dandiarchive.org/blobs/?name=empty.txt"
                             .parse()
@@ -313,11 +314,11 @@ mod tests {
                     size: Some(123456),
                     etag: Some(r#""abcdefgh""#.into()),
                     kind: ResourceKind::Blob,
-                    content: DavContent::Redirect(
+                    content: DavContent::Redirect(Redirect::Direct(
                         "https://dandiarchive-test.s3.amazonaws.com/blobs/spaced%20file.dat"
                             .parse()
                             .unwrap(),
-                    ),
+                    )),
                     metadata_url: Some(
                         "https://api-test.dandiarchive.org/blobs/?name=spaced%20file.dat"
                             .parse()

--- a/src/dav/mod.rs
+++ b/src/dav/mod.rs
@@ -35,6 +35,7 @@ pub(crate) struct DandiDav {
     pub(crate) zarrman: ZarrManClient,
     pub(crate) templater: Templater,
     pub(crate) title: String,
+    pub(crate) prefer_s3_redirects: bool,
 }
 
 impl DandiDav {
@@ -104,9 +105,12 @@ impl DandiDav {
                 ..
             }) => Ok(([(CONTENT_TYPE, content_type)], blob).into_response()),
             DavResourceWithChildren::Item(DavItem {
-                content: DavContent::Redirect(url),
+                content: DavContent::Redirect(redir),
                 ..
-            }) => Ok(Redirect::temporary(url.as_str()).into_response()),
+            }) => Ok(
+                Redirect::temporary(redir.get_url(self.prefer_s3_redirects).as_str())
+                    .into_response(),
+            ),
             DavResourceWithChildren::Item(DavItem {
                 content: DavContent::Missing,
                 ..

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ struct Arguments {
     #[arg(short, long, default_value_t = 8080)]
     port: u16,
 
+    /// Redirect requests for blob assets directly to S3 instead of to Archive
+    /// URLs that redirect to signed S3 URLs
+    #[arg(long)]
+    prefer_s3_redirects: bool,
+
     /// Site name to use in HTML collection pages
     #[arg(short = 'T', long, default_value = env!("CARGO_PKG_NAME"))]
     title: String,
@@ -85,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
         zarrman,
         templater,
         title: args.title,
+        prefer_s3_redirects: args.prefer_s3_redirects,
     });
     let app = Router::new()
         .route(


### PR DESCRIPTION
Closes #92.

Tests on "nightly" are currently failing due to [lint in a dependency](https://github.com/dtolnay/async-trait/issues/259).

@yarikoptic I'm not asking you to review the code, just the behavior.

Note that, the way this is implemented, when the option is in effect, requests for a blob asset (e.g., http://localhost:8080/dandisets/000027/draft/sub-RAT123/sub-RAT123.nwb) will redirect straight to S3, but the link to the asset in the web view (http://localhost:8080/dandisets/000027/draft/sub-RAT123/) will still use the Archive URL.  This should hopefully mitigate the need to have two separate instances running.