### PR TITLE
Set `--prefer-s3-redirects` in deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./dandidav --ip-addr 0.0.0.0 --port $PORT
+web: ./dandidav --ip-addr 0.0.0.0 --port $PORT --prefer-s3-redirects


### PR DESCRIPTION
So that davfs2 will work with dandidav.