### PR TITLE
v0.4.0 — CORS and retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-In Development
---------------
+v0.4.0 (2024-07-09)
+-------------------
 - Set `Access-Control-Allow-Origin: *` header in all responses
 - Log current memory usage before & after handling each request
 - Increased MSRV to 1.76

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "dandidav"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dandidav"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.76"
 description = "WebDAV view to DANDI Archive"


### PR DESCRIPTION
- Set `Access-Control-Allow-Origin: *` header in all responses
- Log current memory usage before & after handling each request
- Increased MSRV to 1.76
- Retry failed outgoing non-S3 HTTP requests
- Accept `PROPFIND` request bodies in which the "include" tag comes before "allprop"