### PR TITLE
Reduce the sizes of a number of streams & futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+In Development
+--------------
+- Reduced the sizes of a number of streams & futures
+
 v0.4.0 (2024-07-09)
 -------------------
 - Set `Access-Control-Allow-Origin: *` header in all responses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,28 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,7 +835,6 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "async-stream",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
+ "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types-convert",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "memory-stats",
  "moka",
  "percent-encoding",
+ "pin-project-lite",
  "pretty_assertions",
  "reqwest",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ async-stream = "0.3.5"
 async-trait = "0.1.81"
 aws-config = { version = "1.5.3", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.39.0"
+aws-smithy-async = "1.2.1"
 aws-smithy-runtime-api = "1.7.1"
 aws-smithy-types-convert = { version = "0.60.8", features = ["convert-time"] }
 axum = { version = "0.7.5", default-features = false, features = ["http1", "tokio", "tower-log"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.86"
-async-stream = "0.3.5"
 async-trait = "0.1.81"
 aws-config = { version = "1.5.3", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.39.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ itertools = "0.13.0"
 memory-stats = "1.2.0"
 moka = { version = "0.12.8", features = ["future"] }
 percent-encoding = "2.3.1"
+pin-project-lite = "0.2.14"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.3.2"
 reqwest-retry = "0.6.0"

--- a/src/dandi/mod.rs
+++ b/src/dandi/mod.rs
@@ -255,17 +255,11 @@ impl<'a> VersionEndpoint<'a> {
         }
     }
 
-    fn get_folder_entries(
-        &self,
-        path: &AssetFolder,
-    ) -> impl Stream<Item = Result<FolderEntry, DandiError>> + '_ {
+    fn get_folder_entries(&self, path: &AssetFolder) -> Paginate<FolderEntry> {
         self.get_entries_under_path(Some(&path.path))
     }
 
-    fn get_entries_under_path(
-        &self,
-        path: Option<&PureDirPath>,
-    ) -> impl Stream<Item = Result<FolderEntry, DandiError>> + '_ {
+    fn get_entries_under_path(&self, path: Option<&PureDirPath>) -> Paginate<FolderEntry> {
         let mut url = self.client.get_url([
             "dandisets",
             self.dandiset_id.as_ref(),

--- a/src/dandi/streams.rs
+++ b/src/dandi/streams.rs
@@ -1,0 +1,82 @@
+use super::types::Page;
+use super::{DandiClient, DandiError};
+use crate::httputil::{Client, HttpError};
+use futures_util::{future::BoxFuture, FutureExt, Stream};
+use pin_project_lite::pin_project;
+use serde::de::DeserializeOwned;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+use url::Url;
+
+pin_project! {
+    // Implementing paginate() as a manually-implemented Stream instead of via
+    // async_stream lets us save about 4700 bytes on dandidav's top-level
+    // Futures.
+    #[must_use = "streams do nothing unless polled"]
+    pub(super) struct Paginate<T> {
+        client: Client,
+        state: PaginateState<T>,
+    }
+}
+
+enum PaginateState<T> {
+    Requesting(BoxFuture<'static, Result<Page<T>, HttpError>>),
+    Yielding {
+        results: std::vec::IntoIter<T>,
+        next: Option<Url>,
+    },
+    Done,
+}
+
+impl<T> Paginate<T> {
+    pub(super) fn new(client: &DandiClient, url: Url) -> Self {
+        Paginate {
+            client: client.inner.clone(),
+            state: PaginateState::Yielding {
+                results: Vec::new().into_iter(),
+                next: Some(url),
+            },
+        }
+    }
+}
+
+impl<T> Stream for Paginate<T>
+where
+    T: DeserializeOwned + 'static,
+{
+    type Item = Result<T, DandiError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        loop {
+            match this.state {
+                PaginateState::Requesting(ref mut fut) => match ready!(fut.as_mut().poll(cx)) {
+                    Ok(page) => {
+                        *this.state = PaginateState::Yielding {
+                            results: page.results.into_iter(),
+                            next: page.next,
+                        }
+                    }
+                    Err(e) => {
+                        *this.state = PaginateState::Done;
+                        return Some(Err(DandiError::from(e))).into();
+                    }
+                },
+                PaginateState::Yielding {
+                    ref mut results,
+                    ref mut next,
+                } => {
+                    if let Some(item) = results.next() {
+                        return Some(Ok(item)).into();
+                    } else if let Some(url) = next.take() {
+                        *this.state =
+                            PaginateState::Requesting(this.client.get_json::<Page<T>>(url).boxed());
+                    } else {
+                        *this.state = PaginateState::Done;
+                    }
+                }
+                PaginateState::Done => return None.into(),
+            }
+        }
+    }
+}

--- a/src/dav/mod.rs
+++ b/src/dav/mod.rs
@@ -43,8 +43,7 @@ impl DandiDav {
         &self,
         req: Request<Body>,
     ) -> Result<Response<Body>, Infallible> {
-        // Box large future:
-        let resp = match Box::pin(self.inner_handle_request(req)).await {
+        let resp = match self.inner_handle_request(req).await {
             Ok(r) => r,
             Err(e) if e.is_404() => {
                 let e = anyhow::Error::from(e);

--- a/src/dav/mod.rs
+++ b/src/dav/mod.rs
@@ -247,8 +247,7 @@ impl DandiDav {
             DavPath::DandisetIndex => {
                 let col = DavCollection::dandiset_index();
                 let mut children = Vec::new();
-                let stream = self.dandi.get_all_dandisets();
-                tokio::pin!(stream);
+                let mut stream = self.dandi.get_all_dandisets();
                 while let Some(ds) = stream.try_next().await? {
                     children.push(DavResource::Collection(ds.into()));
                 }
@@ -282,8 +281,7 @@ impl DandiDav {
                 let col = DavCollection::dandiset_releases(dandiset_id);
                 let mut children = Vec::new();
                 let endpoint = self.dandi.dandiset(dandiset_id.clone());
-                let stream = endpoint.get_all_versions();
-                tokio::pin!(stream);
+                let mut stream = endpoint.get_all_versions();
                 while let Some(v) = stream.try_next().await? {
                     if let VersionId::Published(ref pvid) = v.version {
                         let path = version_path(dandiset_id, &VersionSpec::Published(pvid.clone()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod dav;
 mod httputil;
 mod paths;
 mod s3;
+mod streamutil;
 mod zarrman;
 use crate::consts::{CSS_CONTENT_TYPE, DEFAULT_API_URL, SERVER_VALUE};
 use crate::dandi::DandiClient;

--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -55,8 +55,7 @@ impl S3Client {
         key_prefix: &'a PureDirPath,
     ) -> impl Stream<Item = Result<S3Entry, S3Error>> + 'a {
         try_stream! {
-            let stream = self.list_entry_pages(key_prefix.as_ref());
-            tokio::pin!(stream);
+            let mut stream = self.list_entry_pages(key_prefix.as_ref());
             while let Some(page) = stream.try_next().await? {
                 for entry in page {
                     yield entry;
@@ -70,8 +69,7 @@ impl S3Client {
         let mut surpassed_objects = false;
         let mut surpassed_folders = false;
         let folder_cutoff = format!("{path}/");
-        let stream = self.list_entry_pages(path);
-        tokio::pin!(stream);
+        let mut stream = self.list_entry_pages(path);
         while let Some(page) = stream.try_next().await? {
             if !surpassed_objects {
                 for obj in page.objects {

--- a/src/s3/streams.rs
+++ b/src/s3/streams.rs
@@ -9,6 +9,8 @@ use smartstring::alias::CompactString;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
 pub(super) struct ListEntryPages<'a> {
     bucket: &'a CompactString,
     key_prefix: &'a str,

--- a/src/s3/streams.rs
+++ b/src/s3/streams.rs
@@ -9,6 +9,9 @@ use smartstring::alias::CompactString;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
+// Implementing list_entry_pages() as a manually-implemented Stream instead of
+// via async_stream lets us save about 3500 bytes on dandidav's top-level
+// Futures.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub(super) struct ListEntryPages {

--- a/src/s3/streams.rs
+++ b/src/s3/streams.rs
@@ -1,0 +1,112 @@
+use super::{
+    ListObjectsError, S3Client, S3EntryPage, S3Error, S3Folder, S3Object, TryFromAwsObjectError,
+    TryFromCommonPrefixError,
+};
+use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+use aws_smithy_async::future::pagination_stream::PaginationStream;
+use futures_util::Stream;
+use smartstring::alias::CompactString;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+pub(super) struct ListEntryPages<'a> {
+    bucket: &'a CompactString,
+    key_prefix: &'a str,
+    inner: Option<PaginationStream<Result<ListObjectsV2Output, ListObjectsError>>>,
+}
+
+impl<'a> ListEntryPages<'a> {
+    pub(super) fn new(client: &'a S3Client, key_prefix: &'a str) -> Self {
+        ListEntryPages {
+            bucket: &client.bucket,
+            key_prefix,
+            inner: Some(
+                client
+                    .inner
+                    .list_objects_v2()
+                    .bucket(&*client.bucket)
+                    .prefix(key_prefix)
+                    .delimiter("/")
+                    .into_paginator()
+                    .send(),
+            ),
+        }
+    }
+
+    fn die<T>(&mut self, e: S3Error) -> Poll<Option<Result<T, S3Error>>> {
+        self.inner = None;
+        Some(Err(e)).into()
+    }
+
+    fn die_list_objects<T>(
+        &mut self,
+        source: ListObjectsError,
+    ) -> Poll<Option<Result<T, S3Error>>> {
+        self.die(S3Error::ListObjects {
+            bucket: self.bucket.clone(),
+            prefix: self.key_prefix.to_owned(),
+            source,
+        })
+    }
+
+    fn die_bad_object<T>(
+        &mut self,
+        source: TryFromAwsObjectError,
+    ) -> Poll<Option<Result<T, S3Error>>> {
+        self.die(S3Error::BadObject {
+            bucket: self.bucket.clone(),
+            prefix: self.key_prefix.to_owned(),
+            source,
+        })
+    }
+
+    fn die_bad_prefix<T>(
+        &mut self,
+        source: TryFromCommonPrefixError,
+    ) -> Poll<Option<Result<T, S3Error>>> {
+        self.die(S3Error::BadPrefix {
+            bucket: self.bucket.clone(),
+            prefix: self.key_prefix.to_owned(),
+            source,
+        })
+    }
+}
+
+impl Stream for ListEntryPages<'_> {
+    type Item = Result<S3EntryPage, S3Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Some(inner) = self.inner.as_mut() else {
+            return None.into();
+        };
+        let Some(r) = ready!(inner.poll_next(cx)) else {
+            self.inner = None;
+            return None.into();
+        };
+        let page = match r {
+            Ok(page) => page,
+            Err(source) => return self.die_list_objects(source),
+        };
+        let objects = match page
+            .contents
+            .unwrap_or_default()
+            .into_iter()
+            .map(|obj| S3Object::try_from_aws_object(obj, self.bucket))
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(objects) => objects,
+            Err(source) => return self.die_bad_object(source),
+        };
+        let folders = match page
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .map(S3Folder::try_from)
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(folders) => folders,
+            Err(source) => return self.die_bad_prefix(source),
+        };
+        Some(Ok(S3EntryPage { folders, objects })).into()
+    }
+}

--- a/src/streamutil.rs
+++ b/src/streamutil.rs
@@ -1,0 +1,65 @@
+use futures_util::{Stream, TryStream};
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+pub(crate) trait TryStreamUtil: TryStream {
+    fn try_flat_iter_map<I, F>(self, f: F) -> TryFlatIterMap<Self, I, F>
+    where
+        F: FnMut(Self::Ok) -> I,
+        I: IntoIterator,
+        Self: Sized,
+    {
+        TryFlatIterMap::new(self, f)
+    }
+}
+
+impl<S: TryStream> TryStreamUtil for S {}
+
+pin_project! {
+    #[derive(Clone, Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub(crate) struct TryFlatIterMap<S, I: IntoIterator, F> {
+        #[pin]
+        inner: S,
+        f: F,
+        iter: Option<I::IntoIter>,
+    }
+}
+
+impl<S, I: IntoIterator, F> TryFlatIterMap<S, I, F> {
+    fn new(inner: S, f: F) -> Self {
+        TryFlatIterMap {
+            inner,
+            f,
+            iter: None,
+        }
+    }
+}
+
+impl<S, I, F> Stream for TryFlatIterMap<S, I, F>
+where
+    S: TryStream,
+    F: FnMut(S::Ok) -> I,
+    I: IntoIterator,
+{
+    type Item = Result<I::Item, S::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            if let Some(iter) = this.iter.as_mut() {
+                if let Some(r) = iter.next() {
+                    return Some(Ok(r)).into();
+                } else {
+                    *this.iter = None;
+                }
+            }
+            match ready!(this.inner.as_mut().try_poll_next(cx)) {
+                Some(Ok(iter)) => *this.iter = Some((this.f)(iter).into_iter()),
+                Some(Err(e)) => return Some(Err(e)).into(),
+                None => return None.into(),
+            }
+        }
+    }
+}

--- a/src/validstr.rs
+++ b/src/validstr.rs
@@ -15,6 +15,13 @@ macro_rules! validstr {
             }
         }
 
+        impl From<&$t> for String {
+            #[allow(clippy::string_to_string)]
+            fn from(value: &$t) -> String {
+                value.0.to_string()
+            }
+        }
+
         impl std::fmt::Debug for $t {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{:?}", self.0)


### PR DESCRIPTION
By replacing `async_stream` with a combination of "manually implemented" streams and various stream combinators, along with some other changes, this PR considerably reduces the sizes of a number of stream & future types used by `dandidav`.  In particular, the future for `DandiDav::inner_handle_request()` — previously the largest type in the `dandidav` code proper — went from 17104 bytes to 5784 bytes.