### PR TITLE
Reduce heap usage of various small strings

### DIFF
--- a/src/paths/component.rs
+++ b/src/paths/component.rs
@@ -1,9 +1,10 @@
+use smartstring::alias::CompactString;
 use thiserror::Error;
 
 /// A nonempty path component that does not contain a forward slash or NUL nor
 /// equals `.` or `..`
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) struct Component(pub(super) String);
+pub(crate) struct Component(pub(super) CompactString);
 
 fn validate(s: &str) -> Result<(), ParseComponentError> {
     if s.is_empty() {

--- a/src/paths/dirpath.rs
+++ b/src/paths/dirpath.rs
@@ -46,7 +46,7 @@ impl PureDirPath {
     }
 
     pub(crate) fn name(&self) -> Component {
-        Component(self.name_str().to_owned())
+        Component(self.name_str().into())
     }
 
     pub(crate) fn parent(&self) -> Option<PureDirPath> {
@@ -83,7 +83,7 @@ impl PureDirPath {
 
 impl From<Component> for PureDirPath {
     fn from(value: Component) -> PureDirPath {
-        let mut s = value.0;
+        let mut s = String::from(value);
         s.push('/');
         PureDirPath(s)
     }

--- a/src/paths/purepath.rs
+++ b/src/paths/purepath.rs
@@ -76,7 +76,7 @@ impl PurePath {
     }
 
     pub(crate) fn components(&self) -> impl Iterator<Item = Component> + '_ {
-        self.0.split('/').map(|c| Component(c.to_owned()))
+        self.0.split('/').map(|c| Component(c.into()))
     }
 
     pub(crate) fn push(&mut self, c: &Component) {
@@ -96,7 +96,7 @@ impl PurePath {
 
 impl From<Component> for PurePath {
     fn from(value: Component) -> PurePath {
-        PurePath(value.0)
+        PurePath(value.into())
     }
 }
 


### PR DESCRIPTION
This reduces the parsed size of the largest Zarr manifest from 86,010,142 bytes to 85,025,112 bytes.  It should also make various requests to paths under Zarrs in `/zarrs/` faster (likely imperceptibly so, but still).