### PR TITLE
v0.5.0 — Better Zarr manifest caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-In Development
---------------
+v0.5.0 (2024-11-18)
+-------------------
 - Reduced the sizes of a number of streams & futures
 - Added doc comments to much of the code
 - Return 502 status when a backend returns an invalid response

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "dandidav"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dandidav"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.78"
 description = "WebDAV view to DANDI Archive"


### PR DESCRIPTION
- Reduced the sizes of a number of streams & futures
- Added doc comments to much of the code
- Return 502 status when a backend returns an invalid response
- Require `--api-url` (and other URLs retrieved from APIs) to be HTTP(S)
- Added various developer-facing documents to the repository
- Format all log lines as JSON
- Add logging of Zarr manifest cache events
- Limit Zarr manifest cache by total size of entries
    - Add a `-Z`/`--zarrman-cache-mb` option for setting the cache size
- Expire idle Zarr manifest cache entries
- Log Zarr manifest cache entries every hour
- Increased MSRV to 1.78