### PR TITLE
Upload `lcov.info` as workflow artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,11 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          path: lcov.info
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is a test PR.  Codecov has been taking a long time lately to process coverage results, and I suspect it may be due to `lcov.info` containing superfluous data about dependencies, bloating the file size.

EDIT: Nope, that's not it.