### PR TITLE
v0.6.0 — Assorted performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-In Development
---------------
+v0.6.0 (2025-02-06)
+-------------------
 - Serve a `/robots.txt` file denying all robots
 - Log `User-Agent` and `X-Request-ID` headers
 - Rate limit incoming requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dandidav"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 
 [package]
 name = "dandidav"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "WebDAV view to DANDI Archive"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 DANDI Developers
+Copyright (c) 2024-2025 DANDI Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Serve a `/robots.txt` file denying all robots
- Log `User-Agent` and `X-Request-ID` headers
- Rate limit incoming requests
- Handling of incoming requests now times out after 25 seconds
- Increased MSRV to 1.81
- Outgoing requests to servers other than S3 now time out after 10 seconds
- Memory usage is now only logged if `--log-memory` was supplied on the command line
- Add `--dandi-page-size` option
- Stop providing `getcontenttype` WebDAV property for Zarr entries