### PR TITLE
BF: Address linting errors (by @jwodder)

### DIFF
--- a/src/s3/mod.rs
+++ b/src/s3/mod.rs
@@ -382,7 +382,7 @@ pub(crate) enum S3Error {
     ListObjects {
         bucket: CompactString,
         prefix: String,
-        source: ListObjectsError,
+        source: Box<ListObjectsError>,
     },
     #[error("invalid object found in S3 bucket {bucket:?} under prefix {prefix:?}")]
     BadObject {

--- a/src/s3/streams.rs
+++ b/src/s3/streams.rs
@@ -51,7 +51,7 @@ impl ListEntryPages {
         self.die(S3Error::ListObjects {
             bucket: self.bucket.clone(),
             prefix: self.key_prefix.clone(),
-            source,
+            source: Box::new(source),
         })
     }
 


### PR DESCRIPTION
> The "lint" job of the daily CI has been failing for some time due to clippy getting stricter/better about large enum variants.

from https://github.com/dandi/dandidav/issues/289

Closes #289