### PR TITLE
Release v0.7.0 — Backend optimizations and rate limiting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-In Development
---------------
+v0.7.0 (2025-11-11)
+-------------------
 - Use the Archive API's `/webdav/assets/atpath/` endpoint for fetching
   information about assets
 - Configure rate limiting to allow bursts of up to 50 requests, replenishing
   one request per 50 ms
+- Fix clippy lint compatibility: Replace removed `string_to_string` lint with
+  `implicit_clone` for newer Rust versions
 
 v0.6.0 (2025-03-06)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "dandidav"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 
 [package]
 name = "dandidav"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "WebDAV view to DANDI Archive"

--- a/src/validstr.rs
+++ b/src/validstr.rs
@@ -53,7 +53,7 @@ macro_rules! validstr {
         }
 
         impl From<&$t> for String {
-            #[allow(clippy::string_to_string)]
+            #[allow(clippy::implicit_clone)]
             fn from(value: &$t) -> String {
                 value.0.to_string()
             }


### PR DESCRIPTION
- Use the Archive API's `/webdav/assets/atpath/` endpoint for fetching  information about assets
- Configure rate limiting to allow bursts of up to 50 requests, replenishing one request per 50 ms
- Fix clippy lint compatibility: Replace removed `string_to_string` lint with `implicit_clone` for newer Rust versions
